### PR TITLE
feat(platform): align dataset catalog with ingested studies

### DIFF
--- a/backend/api/openapi.py
+++ b/backend/api/openapi.py
@@ -9,6 +9,23 @@ OPENAPI_SPEC = {
         {"url": "/api/v1"},
     ],
     "paths": {
+        "/datasets": {
+            "get": {
+                "summary": "Dataset catalog grouped by cancer type",
+                "parameters": [
+                    {
+                        "name": "full_catalog",
+                        "in": "query",
+                        "required": False,
+                        "schema": {"type": "string"},
+                        "description": "If 1/true, list all active studies; default lists only studies with ingested clinical patient data.",
+                    }
+                ],
+                "responses": {
+                    "200": {"description": "Grouped map of cancer type to dataset entries"},
+                },
+            }
+        },
         "/datasets/{studyId}/data-status": {
             "get": {
                 "summary": "Study data plane flags (ingested clinical + matrix file on disk)",

--- a/backend/core/study_tables.py
+++ b/backend/core/study_tables.py
@@ -24,6 +24,27 @@ def clinical_patient_table_name(study_id: str) -> str:
     return sanitize_column_name(f"{study_id}_data_clinical_patient")
 
 
+def clinical_sample_table_name(study_id: str) -> str:
+    """Table produced by ingestion for data_clinical_sample.* under a study folder."""
+    return sanitize_column_name(f"{study_id}_data_clinical_sample")
+
+
+def mutations_table_variants(study_id: str) -> tuple[str, str]:
+    """Possible MySQL table names for mutation MAF-style data (cBioPortal naming)."""
+    return (
+        sanitize_column_name(f"{study_id}_data_mutations"),
+        sanitize_column_name(f"{study_id}_data_mutations_extended"),
+    )
+
+
+def gistic_genes_table_variants(study_id: str) -> tuple[str, str]:
+    """GISTIC amp/del gene-level tables."""
+    return (
+        sanitize_column_name(f"{study_id}_data_gistic_genes_amp"),
+        sanitize_column_name(f"{study_id}_data_gistic_genes_del"),
+    )
+
+
 def study_datasets_root() -> Path:
     from utils.config import Config
 

--- a/backend/datasets.example/README.txt
+++ b/backend/datasets.example/README.txt
@@ -1,0 +1,42 @@
+Local cBioPortal-style bundles (two studies example)
+===================================================
+
+The API catalog (GET /api/v1/datasets) reads MySQL table `studies`. Clinical,
+summary, and heatmap expect files under DATASETS_BASE_DIR (default: backend/datasets)
+and — for SQL-backed tabs — tables created by ingestion.
+
+1) Create the data directory (backend/datasets is gitignored; it will not appear in git):
+
+   mkdir -p backend/datasets
+
+2) Copy this index and edit the `name` column to match YOUR folder names (one row per study):
+
+   cp backend/datasets.example/datasets.csv backend/datasets/datasets.csv
+
+3) For each `name` value, add a folder:
+
+   backend/datasets/<name>/
+
+   with cBioPortal-style files (examples: data_clinical_patient.txt, data_clinical_sample.txt,
+   data_mutations.txt, data_gistic_genes_amp.txt, data_mrna_seq_v2_rsem_zscores_ref_all_samples.csv, …).
+
+   The URL path /api/v1/datasets/<name>/... uses the same string as `name` and as `studies.study_id`.
+
+4) Ensure each study appears in MySQL `studies` with is_active=1. The seed migration inserts
+   common TCGA ids (e.g. brca_tcga_pub2015, brca_tcga). For custom ids, INSERT a row yourself.
+
+5) From backend/, with MySQL running and migrations applied:
+
+   python dataloader.py
+
+6) Optional — if the UI lists studies you did not ingest, hide them:
+
+   UPDATE studies SET is_active = 0 WHERE study_id NOT IN ('study_a','study_b');
+
+7) If bundles live outside the repo, set in .env:
+
+   DATASETS_BASE_DIR=/absolute/path/to/parent/of/study/folders
+
+   That directory must still contain datasets.csv and one subfolder per name.
+
+Verify: GET /api/v1/datasets/<name>/data-status

--- a/backend/datasets.example/datasets.csv
+++ b/backend/datasets.example/datasets.csv
@@ -1,0 +1,3 @@
+name
+brca_tcga_pub2015
+brca_tcga

--- a/backend/pipeline/discover.py
+++ b/backend/pipeline/discover.py
@@ -6,6 +6,14 @@ import pandas as pd
 
 def discover_dataset_names(dataset_index_path):
     """Read dataset names from CSV index."""
+    index = Path(dataset_index_path)
+    if not index.is_file():
+        raise FileNotFoundError(
+            f"Dataset index not found: {index}\n"
+            "Create a CSV with a `name` column (one study folder name per row) "
+            "beside your study directories under DATASETS_BASE_DIR. "
+            "In this repo you can start from backend/datasets.example/datasets.csv."
+        ) from None
     df = pd.read_csv(dataset_index_path)
     return df["name"].dropna().astype(str).tolist()
 

--- a/backend/pipeline/matrix_store.py
+++ b/backend/pipeline/matrix_store.py
@@ -14,6 +14,10 @@ MATRIX_KEYWORDS = (
 
 def is_matrix_file(file_path):
     name = os.path.basename(file_path).lower()
+    # cBioPortal per-study tables `data_gistic_genes_{amp,del}.(txt|tsv)` are long-form SQL
+    # loads; only wide matrix-style GISTIC exports should go to Parquet.
+    if "data_gistic_genes" in name:
+        return False
     return any(keyword in name for keyword in MATRIX_KEYWORDS)
 
 

--- a/backend/pipeline/orchestrator.py
+++ b/backend/pipeline/orchestrator.py
@@ -17,6 +17,7 @@ from pipeline.run_tracking import (
     mark_run_failed,
     start_or_resume_run,
 )
+from pipeline.study_catalog import upsert_study_catalog_entry
 from pipeline.transform import build_table_name, parse_case_list, read_dataframe
 from pipeline.validate import validate_dataset_path, validate_file_path
 from pipeline.verify import verify_loaded_tables
@@ -124,6 +125,7 @@ def run_ingestion(dataset_index_path=None, datasets_base_dir=None):
             quality_checks.extend(run_dataset_consistency_checks(engine, dataset_name))
             persist_quality_reports(engine, run_id, dataset_name, quality_checks)
             mark_run_completed(engine, run_id, verification)
+            upsert_study_catalog_entry(engine, dataset_name)
             cache_service.bump_namespace("datasets")
             cache_service.bump_namespace("clinical")
             cache_service.bump_namespace("summary")

--- a/backend/pipeline/study_catalog.py
+++ b/backend/pipeline/study_catalog.py
@@ -1,0 +1,46 @@
+"""Register or refresh catalog rows in ``studies`` after successful ingestion."""
+
+from sqlalchemy import text
+
+
+def upsert_study_catalog_entry(
+    engine,
+    study_id: str,
+    *,
+    type_of_cancer: str = "Breast",
+    display_name: str | None = None,
+):
+    """Ensure ``studies`` has an active row for ``study_id`` (MySQL pipeline engine)."""
+    name = display_name or study_id
+    with engine.begin() as conn:
+        row = conn.execute(
+            text("SELECT id FROM studies WHERE study_id = :sid"),
+            {"sid": study_id},
+        ).first()
+        if row:
+            conn.execute(
+                text(
+                    """
+                    UPDATE studies
+                    SET is_active = 1,
+                        name = :name,
+                        type_of_cancer = :toc,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE study_id = :sid
+                    """
+                ),
+                {"sid": study_id, "name": name, "toc": type_of_cancer},
+            )
+        else:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO studies (
+                        study_id, type_of_cancer, name, is_active, created_at, updated_at
+                    ) VALUES (
+                        :sid, :toc, :name, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                    )
+                    """
+                ),
+                {"sid": study_id, "toc": type_of_cancer, "name": name},
+            )

--- a/backend/repositories/dataset_repository.py
+++ b/backend/repositories/dataset_repository.py
@@ -3,22 +3,38 @@ from sqlalchemy import text
 from utils.database import get_db
 
 
+def _use_flask_sqlalchemy_session():
+    try:
+        from flask import has_app_context
+
+        return has_app_context()
+    except RuntimeError:
+        return False
+
+
 class DatasetRepository:
-    """Read-only access to study rows exposed as dataset catalog entries."""
+    """Read-only access to study rows exposed as dataset catalog entries.
+
+    Uses Flask-SQLAlchemy inside an app context (tests + web) so the catalog matches
+    the same engine as ORM models; otherwise ``utils.database`` (MySQL) for workers.
+    """
 
     def fetch_all(self):
+        q = text(
+            """
+            SELECT study_id AS id, name, type_of_cancer AS type
+            FROM studies
+            WHERE is_active = 1
+            ORDER BY type_of_cancer, name
+            """
+        )
+        if _use_flask_sqlalchemy_session():
+            from extensions import db as flask_db
+
+            return flask_db.session.execute(q).mappings().all()
         db = next(get_db())
         try:
-            return db.execute(
-                text(
-                    """
-                    SELECT study_id AS id, name, type_of_cancer AS type
-                    FROM studies
-                    WHERE is_active = 1
-                    ORDER BY type_of_cancer, name
-                    """
-                )
-            ).mappings().all()
+            return db.execute(q).mappings().all()
         finally:
             db.close()
 

--- a/backend/routes/datasets.py
+++ b/backend/routes/datasets.py
@@ -1,3 +1,4 @@
+from flask import request
 from flask_restful import Resource
 
 from api.error_response import internal_error_response
@@ -5,19 +6,30 @@ from services.cache_service import cache_service
 from services.dataset_service import DatasetService
 
 
+def _truthy_full_catalog(val: str | None) -> bool:
+    if val is None:
+        return False
+    return val.strip().lower() in ("1", "true", "yes", "full")
+
+
 class Datasets(Resource):
     def __init__(self):
         self.service = DatasetService()
 
     def get(self):
-        """Return all datasets grouped by type"""
+        """Return datasets grouped by type.
+
+        By default only studies with an ingested clinical patient table are listed.
+        Pass ``?full_catalog=1`` to include all active catalog rows (operators / deep links).
+        """
         try:
-            cache_key = "all"
+            full_catalog = _truthy_full_catalog(request.args.get("full_catalog"))
+            cache_key = "full" if full_catalog else "ingested"
             cached = cache_service.get_json("datasets", cache_key)
             if cached is not None:
                 return cached
 
-            payload = self.service.get_grouped_datasets()
+            payload = self.service.get_grouped_datasets(full_catalog=full_catalog)
             cache_service.set_json("datasets", cache_key, payload)
             return payload
         except Exception:

--- a/backend/routes/study_data_status.py
+++ b/backend/routes/study_data_status.py
@@ -5,10 +5,20 @@ from flask_restful import Resource
 from api.error_response import api_error
 from core.study_tables import (
     clinical_patient_table_name,
+    clinical_sample_table_name,
     expression_matrix_path,
+    gistic_genes_table_variants,
+    mutations_table_variants,
     parse_study_id,
 )
 from repositories.clinical_repository import ClinicalRepository
+
+
+def _first_existing_table(repo: ClinicalRepository, names: tuple[str, ...]) -> str | None:
+    for name in names:
+        if repo.has_table(name):
+            return name
+    return None
 
 
 class StudyDataStatus(Resource):
@@ -21,12 +31,31 @@ class StudyDataStatus(Resource):
         study = parse_study_id(dataset_name)
         if study is None:
             return api_error("INVALID_REQUEST", "Invalid study id."), 400
-        clinical_table = clinical_patient_table_name(study)
+        patient_table = clinical_patient_table_name(study)
+        sample_table = clinical_sample_table_name(study)
+        clinical_patient = self._clinical_repo.has_table(patient_table)
+        clinical_sample = self._clinical_repo.has_table(sample_table)
+        mutations_table = _first_existing_table(
+            self._clinical_repo, mutations_table_variants(study)
+        )
+        gistic_table = _first_existing_table(
+            self._clinical_repo, gistic_genes_table_variants(study)
+        )
         matrix_path = expression_matrix_path(study)
+        summary_ready = (
+            clinical_patient
+            and clinical_sample
+            and mutations_table is not None
+            and gistic_table is not None
+        )
         return (
             {
                 "study_id": study,
-                "clinical_patient_ingested": self._clinical_repo.has_table(clinical_table),
+                "clinical_patient_ingested": clinical_patient,
+                "clinical_sample_ingested": clinical_sample,
+                "mutations_table": mutations_table,
+                "gistic_table": gistic_table,
+                "summary_ready": summary_ready,
                 "expression_matrix_file_present": matrix_path.is_file(),
             },
             200,

--- a/backend/routes/summary.py
+++ b/backend/routes/summary.py
@@ -11,6 +11,7 @@ from sqlalchemy import text
 
 from api.error_response import api_error, internal_error_response
 from core.study_tables import parse_study_id
+from repositories.clinical_repository import ClinicalRepository
 from services.cache_service import cache_service
 from utils.database import get_db
 
@@ -23,9 +24,14 @@ def _study_tables(dataset_name: str):
         "study": study,
         "patient": f"{study}_data_clinical_patient",
         "sample": f"{study}_data_clinical_sample",
-        "mutations": f"{study}_data_mutations",
-        "gistic_amp": f"{study}_data_gistic_genes_amp",
     }
+
+
+def _first_existing_table(repo: ClinicalRepository, candidates: tuple[str, ...]) -> str | None:
+    for name in candidates:
+        if repo.has_table(name):
+            return name
+    return None
 
 
 class Summary(Resource):
@@ -38,13 +44,40 @@ class Summary(Resource):
             study = tables["study"]
             patient_table = tables["patient"]
             sample_table = tables["sample"]
-            mutations_table = tables["mutations"]
-            gistic_table = tables["gistic_amp"]
 
             cache_key = f"{study}:full"
             cached = cache_service.get_json("summary", cache_key)
             if cached is not None:
                 return cached, HTTPStatus.OK
+
+            repo = ClinicalRepository()
+            mutations_table = _first_existing_table(
+                repo,
+                (f"{study}_data_mutations", f"{study}_data_mutations_extended"),
+            )
+            gistic_table = _first_existing_table(
+                repo,
+                (f"{study}_data_gistic_genes_amp", f"{study}_data_gistic_genes_del"),
+            )
+            missing = [t for t in (patient_table, sample_table) if not repo.has_table(t)]
+            if mutations_table is None:
+                missing.append(
+                    f"{study}_data_mutations or {study}_data_mutations_extended"
+                )
+            if gistic_table is None:
+                missing.append(
+                    f"{study}_data_gistic_genes_amp or {study}_data_gistic_genes_del"
+                )
+            if missing:
+                return (
+                    api_error(
+                        "NOT_INGESTED",
+                        "Summary needs ingested cBioPortal-style tables for this study "
+                        f"(missing: {', '.join(missing)}). From backend/, run ingestion after "
+                        "placing study files under DATASETS_BASE_DIR.",
+                    ),
+                    HTTPStatus.NOT_FOUND,
+                )
 
             response_data = {}
             db = next(get_db())

--- a/backend/services/dataset_service.py
+++ b/backend/services/dataset_service.py
@@ -1,14 +1,23 @@
+from core.study_tables import clinical_patient_table_name
+from repositories.clinical_repository import ClinicalRepository
 from repositories.dataset_repository import DatasetRepository
 
 
 class DatasetService:
     """Business logic for dataset presentation."""
 
-    def __init__(self, repository=None):
+    def __init__(self, repository=None, clinical_repository=None):
         self.repository = repository or DatasetRepository()
+        self._clinical = clinical_repository or ClinicalRepository()
 
-    def get_grouped_datasets(self):
+    def get_grouped_datasets(self, full_catalog: bool = False):
         rows = self.repository.fetch_all()
+        if not full_catalog:
+            rows = [
+                row
+                for row in rows
+                if self._clinical.has_table(clinical_patient_table_name(row["id"]))
+            ]
         grouped_datasets = {}
 
         for row in rows:

--- a/backend/tests/api/test_platform_api.py
+++ b/backend/tests/api/test_platform_api.py
@@ -50,4 +50,79 @@ def test_study_data_status_ok_shape(client):
     body = r.get_json()
     assert body["study_id"] == "brca_tcga_pub2015"
     assert "clinical_patient_ingested" in body
+    assert "clinical_sample_ingested" in body
+    assert "mutations_table" in body
+    assert "gistic_table" in body
+    assert "summary_ready" in body
+    assert body["summary_ready"] is False
     assert "expression_matrix_file_present" in body
+
+
+def test_datasets_default_empty_without_clinical_table(client, app):
+    from extensions import db
+    from models.study import Study
+
+    with app.app_context():
+        db.session.add(
+            Study(
+                study_id="ghost_study",
+                type_of_cancer="Breast",
+                name="Ghost",
+                is_active=True,
+            )
+        )
+        db.session.commit()
+
+    r = client.get("/api/v1/datasets")
+    assert r.status_code == 200
+    body = r.get_json()
+    for rows in body.values():
+        assert not any(d.get("id") == "ghost_study" for d in rows)
+
+    r_full = client.get("/api/v1/datasets?full_catalog=1")
+    assert r_full.status_code == 200
+    full = r_full.get_json()
+    breast = full.get("Breast", [])
+    assert any(d.get("id") == "ghost_study" for d in breast)
+
+
+def test_datasets_lists_study_after_clinical_table_exists(client, app):
+    from sqlalchemy import text
+
+    from extensions import db
+    from models.study import Study
+
+    with app.app_context():
+        db.session.add(
+            Study(
+                study_id="ingested_demo",
+                type_of_cancer="Breast",
+                name="Ingested Demo",
+                is_active=True,
+            )
+        )
+        db.session.commit()
+        db.session.execute(
+            text(
+                "CREATE TABLE ingested_demo_data_clinical_patient ("
+                "patient_id VARCHAR(64), os_status VARCHAR(32), os_months FLOAT, "
+                "age INT, race VARCHAR(64), sex VARCHAR(32), "
+                "ajcc_pathologic_tumor_stage VARCHAR(64), days_to_birth VARCHAR(64), "
+                "days_to_last_followup VARCHAR(64), dfs_months VARCHAR(64), dfs_status VARCHAR(64))"
+            )
+        )
+        db.session.commit()
+
+    r = client.get("/api/v1/datasets")
+    assert r.status_code == 200
+    body = r.get_json()
+    breast = body.get("Breast", [])
+    assert any(d.get("id") == "ingested_demo" for d in breast)
+
+
+def test_summary_not_ingested_without_study_tables(client):
+    r = client.get("/api/v1/datasets/brca_tcga_pub2015/summary")
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body.get("error", {}).get("code") == "NOT_INGESTED"
+    assert "missing" in body.get("error", {}).get("message", "").lower()

--- a/backend/tests/unit/test_matrix_store.py
+++ b/backend/tests/unit/test_matrix_store.py
@@ -1,0 +1,10 @@
+from pipeline.matrix_store import is_matrix_file
+
+
+def test_gistic_genes_tables_are_not_treated_as_wide_matrices():
+    assert is_matrix_file("/x/data_gistic_genes_amp.txt") is False
+    assert is_matrix_file("/x/data_gistic_genes_del.txt") is False
+
+
+def test_other_gistic_named_files_can_still_be_matrices():
+    assert is_matrix_file("/x/all_thresholded_by_genes_gistic2.txt") is True

--- a/frontend/src/components/DatasetDetail/DatasetDetail.css
+++ b/frontend/src/components/DatasetDetail/DatasetDetail.css
@@ -42,6 +42,12 @@
     border-bottom: 2px solid #3182ce;
   }
 
+  .tabs button:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    color: #a0aec0;
+  }
+
   .tabs button:focus-visible {
     outline: 2px solid #4299e1;
     outline-offset: 2px;

--- a/frontend/src/components/DatasetDetail/DatasetDetail.js
+++ b/frontend/src/components/DatasetDetail/DatasetDetail.js
@@ -54,6 +54,34 @@ const DatasetDetail = () => {
     [setSearchParams],
   );
 
+  const tabAvailability = useMemo(() => {
+    if (!dataStatus) {
+      return {
+        summary: true,
+        clinical: true,
+        analysis: true,
+        heatmap: true,
+      };
+    }
+    return {
+      summary: Boolean(dataStatus.summary_ready),
+      clinical: Boolean(dataStatus.clinical_patient_ingested),
+      analysis: Boolean(dataStatus.clinical_patient_ingested),
+      heatmap: Boolean(dataStatus.expression_matrix_file_present),
+    };
+  }, [dataStatus]);
+
+  useEffect(() => {
+    if (!dataStatus) return;
+    const ok = tabAvailability;
+    if (ok[activeTab]) return;
+    const order = ['clinical', 'summary', 'analysis', 'heatmap'];
+    const next = order.find((id) => ok[id]);
+    if (next && next !== activeTab) {
+      setActiveTab(next);
+    }
+  }, [dataStatus, activeTab, tabAvailability, setActiveTab]);
+
   useEffect(() => {
     let cancelled = false;
 
@@ -126,17 +154,30 @@ const DatasetDetail = () => {
       </Link>
       <h1 className="dataset-title">{dataset.name}</h1>
       <p className="dataset-type text-muted">{dataset.type}</p>
-      {dataStatus &&
-        (!dataStatus.clinical_patient_ingested ||
-          !dataStatus.expression_matrix_file_present) && (
+      {dataStatus && (
         <Alert variant="info" className="mb-3" role="status">
           <Alert.Heading className="h6">Data plane status</Alert.Heading>
           <ul className="mb-0 small">
             <li>
-              Clinical table ingested:{' '}
+              Clinical patient table:{' '}
               <strong>{dataStatus.clinical_patient_ingested ? 'yes' : 'no'}</strong>
-              {!dataStatus.clinical_patient_ingested &&
-                ' — run ingestion after placing cBioPortal-style files under DATASETS_BASE_DIR.'}
+            </li>
+            <li>
+              Clinical sample table:{' '}
+              <strong>{dataStatus.clinical_sample_ingested ? 'yes' : 'no'}</strong>
+            </li>
+            <li>
+              Mutations (SQL):{' '}
+              <strong>{dataStatus.mutations_table ? dataStatus.mutations_table : 'no'}</strong>
+            </li>
+            <li>
+              GISTIC genes table:{' '}
+              <strong>{dataStatus.gistic_table ? dataStatus.gistic_table : 'no'}</strong>
+            </li>
+            <li>
+              Summary tab ready: <strong>{dataStatus.summary_ready ? 'yes' : 'no'}</strong>
+              {!dataStatus.summary_ready &&
+                ' — needs patient + sample + mutations + GISTIC tables ingested.'}
             </li>
             <li>
               Expression matrix CSV on disk:{' '}
@@ -163,21 +204,29 @@ const DatasetDetail = () => {
         role="tablist"
         aria-label="Study sections"
       >
-        {TABS.map((tab) => (
-          <button
-            key={tab.id}
-            type="button"
-            role="tab"
-            id={`tab-${tab.id}`}
-            aria-selected={activeTab === tab.id}
-            aria-controls={`panel-${tab.id}`}
-            tabIndex={activeTab === tab.id ? 0 : -1}
-            className={activeTab === tab.id ? 'active' : ''}
-            onClick={() => setActiveTab(tab.id)}
-          >
-            {tab.label}
-          </button>
-        ))}
+        {TABS.map((tab) => {
+          const enabled = tabAvailability[tab.id];
+          const title = !enabled
+            ? 'Not available for this study (see data plane status above).'
+            : undefined;
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              role="tab"
+              id={`tab-${tab.id}`}
+              title={title}
+              aria-selected={activeTab === tab.id}
+              aria-controls={`panel-${tab.id}`}
+              tabIndex={activeTab === tab.id ? 0 : -1}
+              disabled={!enabled}
+              className={activeTab === tab.id ? 'active' : ''}
+              onClick={() => enabled && setActiveTab(tab.id)}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
       </div>
 
       <div className="tab-content">

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -118,15 +118,31 @@ export function findDatasetInGrouped(grouped, datasetId) {
 }
 
 export const datasetService = {
-  getAllDatasets: async () => {
-    const response = await apiClient.get('/datasets');
+  /**
+   * @param {{ fullCatalog?: boolean }} [options]
+   * Default list includes only studies with ingested clinical patient data.
+   * Set fullCatalog true for operator catalog (matches `?full_catalog=1`).
+   */
+  getAllDatasets: async (options = {}) => {
+    const params = {};
+    if (options.fullCatalog) {
+      params.full_catalog = '1';
+    }
+    const response = await apiClient.get('/datasets', { params });
     return response.data;
   },
 
-  /** Resolve study metadata from GET /datasets (single source of truth). */
+  /**
+   * Resolve study metadata: prefer ingested-only list, then full catalog (deep links).
+   */
   getDatasetMeta: async (datasetId) => {
-    const grouped = await datasetService.getAllDatasets();
-    return findDatasetInGrouped(grouped, datasetId);
+    let grouped = await datasetService.getAllDatasets({ fullCatalog: false });
+    let meta = findDatasetInGrouped(grouped, datasetId);
+    if (!meta) {
+      grouped = await datasetService.getAllDatasets({ fullCatalog: true });
+      meta = findDatasetInGrouped(grouped, datasetId);
+    }
+    return meta;
   },
 
   getClinicalData: async (datasetId, params = {}) => {


### PR DESCRIPTION
Default dataset listing now reflects ingested backend truth, with a full-catalog override and richer per-study capability flags so UI exploration only shows available tabs. Ingestion now upserts studies metadata after successful runs and matrix handling preserves SQL GISTIC tables expected by summary.